### PR TITLE
Kamal deploy scaffold: viz-cx-api on axveer (api.viz.cx + node.viz.cx redirect)

### DIFF
--- a/.kamal/hooks/post-deploy
+++ b/.kamal/hooks/post-deploy
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Attach this app's container to platform_net on each target host so it can
+# reach the shared mongo (it lives on platform_net, not Kamal's default 'kamal'
+# network). Kamal runs hooks LOCALLY, so we SSH to each host.
+#
+# Kamal 2 hook env: KAMAL_SERVICE / KAMAL_ROLE / KAMAL_VERSION / KAMAL_HOSTS
+# (there is NO KAMAL_CONTAINERS). Container name = service-role-version.
+set -euo pipefail
+container="${KAMAL_SERVICE}-${KAMAL_ROLE:-web}-${KAMAL_VERSION}"
+IFS=',' read -ra hosts <<< "${KAMAL_HOSTS:?}"
+for host in "${hosts[@]}"; do
+    # deploy is in the docker group, so Kamal (and we) run docker without sudo;
+    # ssh port 666 per inventory.yml. || true: re-attach is a no-op idempotently.
+    ssh -p 666 "deploy@${host}" \
+        "docker network connect platform_net '${container}' 2>/dev/null || true"
+done

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # Vars consumed by Kamal externally.
+# Pulls credentials from the sibling infrastructure repo's SOPS files.
+# Kamal parses this file with dotenv (NOT bash): plain assignment + $(...) work,
+# but bash default-expansion ${VAR:-default} does not — keep this a literal.
+INFRA=../../infra
+
+# Extract only the keys needed — everything else stays encrypted and out of
+# this process env.
+KAMAL_REGISTRY_PASSWORD=$(sops -d --extract '["docker_registry_password"]' "$INFRA/secrets/shared.enc.yaml")
+
+# Full mongodb:// URI incl. the viz-cx-api app-user credentials (axveer shared
+# mongo requires auth). Provisioned by infra's scripts/add-app.sh.
+MONGO=$(sops -d --extract '["db_uri"]' "$INFRA/secrets/apps/viz-cx-api.enc.yaml")

--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,7 @@
+.venv
+.env
+__pycache__
+.pytest_cache
+.ruff_cache
+.vscode
+.DS_Store

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -8,4 +8,7 @@ RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 
 COPY ./ /code/
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# --proxy-headers + forwarded-allow-ips: trust X-Forwarded-Proto from
+# kamal-proxy (it connects from the docker network, not 127.0.0.1) so
+# redirects/url_for emit https, not http.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,11 @@
-FROM python:3.10
+FROM python:3.12
 
 WORKDIR /code
 
-COPY ./ /code/
+COPY requirements.txt /code/requirements.txt
 
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+COPY ./ /code/
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -45,8 +45,11 @@ async def lifespan(app: FastAPI):
     yield
 
 
+# root_path "" (FastAPI's default) when serving at the domain root; "/" makes
+# Starlette 307-redirect every path (/ -> //, /playground/ -> 404). Set
+# ROOT_PATH only when mounted under a stripped prefix (e.g. /api/v1).
 app = FastAPI(
-    title="VIZ.cx API", root_path=os.getenv("ROOT_PATH", "/"), lifespan=lifespan
+    title="VIZ.cx API", root_path=os.getenv("ROOT_PATH", ""), lifespan=lifespan
 )
 app.include_router(router)
 

--- a/api/main.py
+++ b/api/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from threading import Thread
 
 from dotenv import load_dotenv
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi_cache import FastAPICache
@@ -49,6 +49,22 @@ app = FastAPI(
     title="VIZ.cx API", root_path=os.getenv("ROOT_PATH", "/"), lifespan=lifespan
 )
 app.include_router(router)
+
+
+@app.middleware("http")
+async def redirect_legacy_rpc_host(request: Request, call_next):
+    """node.viz.cx is the legacy public VIZ RPC name — 308 it to the live node.
+
+    Host-scoped: kamal-proxy healthchecks carry a container-address Host and
+    are never redirected. 308 (not 301) so JSON-RPC POSTs keep their
+    method+body when followed. wss:// clients are not covered — websocket
+    handshakes bypass HTTP middleware; legacy /ws users must repoint."""
+    if request.headers.get("host", "").split(":")[0] == "node.viz.cx":
+        target = "https://rpc.viz.cx:19443" + request.url.path
+        if request.url.query:
+            target += "?" + request.url.query
+        return Response(status_code=308, headers={"Location": target})
+    return await call_next(request)
 
 _playground_dir = os.path.join(os.path.dirname(__file__), "static", "playground")
 if os.path.isdir(_playground_dir):

--- a/api/tests/test_legacy_rpc_redirect.py
+++ b/api/tests/test_legacy_rpc_redirect.py
@@ -1,0 +1,27 @@
+"""node.viz.cx host-scoped 308 redirect (middleware in main.py).
+
+The legacy public VIZ RPC name must 308 to the live node with method, path
+and query preserved, while every other Host — including the container-address
+Host that kamal-proxy healthchecks send — is untouched.
+"""
+
+
+def test_node_viz_cx_post_redirects_with_path_and_query(client):
+    response = client.post(
+        "/some/path?foo=bar",
+        headers={"Host": "node.viz.cx"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 308
+    assert response.headers["location"] == "https://rpc.viz.cx:19443/some/path?foo=bar"
+
+
+def test_node_viz_cx_with_port_redirects(client):
+    response = client.get("/", headers={"Host": "node.viz.cx:443"}, follow_redirects=False)
+    assert response.status_code == 308
+    assert response.headers["location"] == "https://rpc.viz.cx:19443/"
+
+
+def test_other_hosts_unaffected(client):
+    response = client.get("/", headers={"Host": "api.viz.cx"})
+    assert response.status_code == 200

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,0 +1,67 @@
+# Kamal deploy config for the viz.cx API — single FastAPI container (uvicorn
+# :8000) with parser/sorter/posts worker threads inside. API-only deploy: the
+# legacy box (138.201.117.201) keeps serving the viz.cx site frontend; this app
+# serves api.viz.cx and carries node.viz.cx solely for the 308 redirect to
+# https://rpc.viz.cx:19443 (FastAPI middleware in api/main.py — kamal-proxy
+# issues/renews the cert because the host is listed here; node.viz.cx does NOT
+# go into infra's tls-hosts.txt, redirect-only hosts never do).
+#
+# Data: shared platform MongoDB, db `viz-cx-api` (the legacy 15.2 GB
+# `viz-blockchain` db restored with ns remap — infra runbook-viz-migration §10).
+# Chain feed: the VIZ RPC node on vpn-amnezia. The app calls mongo AND the node
+# during boot (lifespan: init_node + ensure_indexes), so it relies on
+# platform-up.sh's mongo bridge onto the kamal network — hostname `mongo`
+# resolves at container boot; the post-deploy hook adds platform_net after.
+
+service: viz-cx-api
+image:   chiliec/viz-cx-api        # GHCR: composed to ghcr.io/chiliec/viz-cx-api via registry.server
+
+servers:
+  web:
+    hosts:
+      - 5.223.75.86               # axveer VPS public IPv4
+
+ssh:
+  user: deploy
+  port: 666                       # hardened sshd per infra inventory.yml
+
+proxy:
+  hosts:
+    - api.viz.cx                  # the API's own name (A record → axveer)
+    - node.viz.cx                 # legacy RPC name — 308 middleware only
+  app_port: 8000
+  ssl: true
+  healthcheck:
+    path: /                       # others.py home() — node info round-trip;
+                                  # only polled during deploy. Fail-closed: the
+                                  # lifespan already hard-fails boot if the VIZ
+                                  # node or mongo is unreachable.
+
+registry:
+  server: ghcr.io
+  username: chiliec
+  password:
+    - KAMAL_REGISTRY_PASSWORD     # GHCR PAT (write:packages) — SOPS shared.enc.yaml docker_registry_password
+
+env:
+  clear:
+    DB_NAME: viz-cx-api           # restored from legacy `viz-blockchain` (ns remap)
+    COLLECTION: blocks4           # legacy collection names carried over as-is
+    COLLECTION_OPS: ops
+    COLLECTION_POSTS: posts
+    # COLLECTION_ROLLUPS / COLLECTION_WEBHOOKS use code defaults (rollups/webhooks)
+    VIZ_NODES: https://rpc.viz.cx:19443
+    # Parser floor: first block with op history on rpc.viz.cx (snapshot-sync
+    # node, bootstrapped 2026-06-11; probed empirically). Blocks
+    # 79,105,831–80,679,604 are a known unfillable hole — no reachable node
+    # serves them (see commit 1f6663f; the 80,463,600 bound there assumed the
+    # legacy vizd, which is wedged).
+    PARSER_START_BLOCK: "80679605"
+    LOG_LEVEL: INFO
+  secret:                         # decrypted from SOPS via .kamal/secrets
+    - MONGO                       # full mongodb:// URI incl. app-user creds
+
+builder:
+  arch: amd64
+  context: api                    # build context = api/ (kamal chdirs to the
+  dockerfile: api/Dockerfile      # git clone root; both paths resolve from there)

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -58,9 +58,8 @@ env:
     # legacy vizd, which is wedged).
     PARSER_START_BLOCK: "80679605"
     LOG_LEVEL: INFO
-    ROOT_PATH: ""                 # FastAPI wants "" when serving at the domain
-                                  # root; the code default "/" makes every path
-                                  # 307-redirect (/ -> //, /playground -> 404)
+    # ROOT_PATH unset on purpose: kamal drops empty-string env values, so the
+    # "" default lives in api/main.py. Set it only under a stripped prefix.
   secret:                         # decrypted from SOPS via .kamal/secrets
     - MONGO                       # full mongodb:// URI incl. app-user creds
 

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -58,6 +58,9 @@ env:
     # legacy vizd, which is wedged).
     PARSER_START_BLOCK: "80679605"
     LOG_LEVEL: INFO
+    ROOT_PATH: ""                 # FastAPI wants "" when serving at the domain
+                                  # root; the code default "/" makes every path
+                                  # 307-redirect (/ -> //, /playground -> 404)
   secret:                         # decrypted from SOPS via .kamal/secrets
     - MONGO                       # full mongodb:// URI incl. app-user creds
 

--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -1,8 +1,9 @@
 # node.viz.cx is the legacy public VIZ RPC name — 308 it to the live endpoint
-# (the VIZ node on vpn-amnezia, stood up 2026-06-11). This block MUST ship with
-# the viz.cx deploy to axveer: node.viz.cx DNS is already pre-pointed at axveer
-# (5.223.75.86) and the host goes into the app's kamal proxy.hosts (cert from
-# kamal-proxy; redirect-only hosts do NOT go into infra's tls-hosts.txt).
+# (the VIZ node on vpn-amnezia, stood up 2026-06-11). LIVE IMPLEMENTATION: the
+# FastAPI middleware in api/main.py (the axveer deploy is API-only, no nginx);
+# node.viz.cx sits in config/deploy.yml proxy.hosts (cert from kamal-proxy;
+# redirect-only hosts do NOT go into infra's tls-hosts.txt). This nginx block
+# documents the same contract for any future nginx-fronted deployment.
 # 308 (not 301) so JSON-RPC POSTs keep their method+body when followed.
 server {
     listen 80;


### PR DESCRIPTION
Deploys the API to axveer as Kamal app `viz-cx-api` — LIVE since 2026-06-11 (deployed commit 62f0db4).

- `config/deploy.yml`: `proxy.hosts: [api.viz.cx, node.viz.cx]`, shared platform mongo db `viz-cx-api` (legacy `viz-blockchain` restored, 184.6M docs exact), `VIZ_NODES=https://rpc.viz.cx:19443`, `PARSER_START_BLOCK=80679605` (first block with op history on the snapshot-synced node, probed).
- node.viz.cx host-scoped 308 middleware → `https://rpc.viz.cx:19443` (+3 tests; replaces the planned nginx block — example header updated). wss:// clients are not covered (handshakes bypass HTTP middleware) and must repoint manually.
- Dockerfile: `python:3.12` (pyproject requires ≥3.11), requirements layer caching, `--proxy-headers --forwarded-allow-ips "*"` (uvicorn must trust X-Forwarded-Proto from kamal-proxy), `.dockerignore`.
- `root_path` defaults to `""` — the `"/"` default made Starlette 307-redirect every path (`/` → `//`, `/playground/` → 404). NB kamal silently drops empty-string env values, hence the fix in code.

Ops detail in the infra repo: `docs/runbook-viz-migration.md` §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)