### PR TITLE
feat(web): global toast notifications for broadcast actions

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -97,6 +97,16 @@ async def proxy_legacy_rpc_host(request: Request, call_next):
     if request.headers.get("host", "").split(":")[0] != LEGACY_RPC_HOST:
         return await call_next(request)
 
+    _cors = {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "GET, POST, OPTIONS",
+        "access-control-allow-headers": "*",
+    }
+
+    # Public RPC — respond to CORS preflight immediately without hitting upstream.
+    if request.method == "OPTIONS":
+        return Response(status_code=200, headers=_cors)
+
     url = RPC_UPSTREAM + request.url.path
     if request.url.query:
         url += "?" + request.url.query
@@ -116,6 +126,7 @@ async def proxy_legacy_rpc_host(request: Request, call_next):
         if k.lower() not in _HOP_BY_HOP
         and k.lower() not in ("content-length", "content-encoding")
     }
+    resp_headers.update(_cors)
     return Response(
         content=upstream.content,
         status_code=upstream.status_code,

--- a/api/main.py
+++ b/api/main.py
@@ -97,16 +97,6 @@ async def proxy_legacy_rpc_host(request: Request, call_next):
     if request.headers.get("host", "").split(":")[0] != LEGACY_RPC_HOST:
         return await call_next(request)
 
-    _cors = {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, POST, OPTIONS",
-        "access-control-allow-headers": "*",
-    }
-
-    # Public RPC — respond to CORS preflight immediately without hitting upstream.
-    if request.method == "OPTIONS":
-        return Response(status_code=200, headers=_cors)
-
     url = RPC_UPSTREAM + request.url.path
     if request.url.query:
         url += "?" + request.url.query
@@ -126,7 +116,6 @@ async def proxy_legacy_rpc_host(request: Request, call_next):
         if k.lower() not in _HOP_BY_HOP
         and k.lower() not in ("content-length", "content-encoding")
     }
-    resp_headers.update(_cors)
     return Response(
         content=upstream.content,
         status_code=upstream.status_code,
@@ -194,11 +183,10 @@ if os.path.isdir(_playground_dir):
         name="playground",
     )
 
-origins = ["https://viz.cx", "http://localhost:3000"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
+    allow_origins=["*"],
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -95,3 +95,12 @@ body {
 .row-in {
   animation: row-in 1.2s ease-out;
 }
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(1rem); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.toast-enter { animation: toast-in 0.18s ease-out; }
+@media (prefers-reduced-motion: reduce) {
+  .toast-enter { animation: none; }
+}

--- a/web/components/AwardModal.tsx
+++ b/web/components/AwardModal.tsx
@@ -1,7 +1,8 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { createHttpTransport, createReadApi } from '@viz-cx/core'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { awardAccount } from '@/lib/actions'
 import { NODE_ENDPOINTS } from '@/lib/config'
 import { currentEnergy } from '@/lib/format'
@@ -17,19 +18,17 @@ const PRESETS = [10, 25, 50, 100]
 
 export function AwardModal({ open, onClose, receiver }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [energyPct, setEnergyPct] = useState(25)
   const [customInput, setCustomInput] = useState('')
   const [memo, setMemo] = useState('')
   const [availableEnergy, setAvailableEnergy] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setCustomInput(''); setMemo(''); setError(null); setDone(false)
+      setCustomInput(''); setMemo(''); setError(null)
       setEnergyPct(25); setAvailableEnergy(null)
     }
   }, [open])
@@ -60,19 +59,16 @@ export function AwardModal({ open, onClose, receiver }: Props) {
     setError(null); setLoading(true)
     try {
       await awardAccount(wif, wallet.account!, receiver, clampedPct, memo || undefined)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(`Awarded ${clampedPct}% energy to @${receiver}`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
   return (
     <ModalShell open={open} onClose={onClose} title={`Award @${receiver}`}>
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <div className="flex flex-col gap-1.5">
               <label htmlFor="award-energy" className="text-[10px] font-prose font-semibold uppercase tracking-widest text-fg-dim">
                 Energy %{availableEnergy !== null ? ` (${availableEnergy}% available)` : ''}
@@ -129,7 +125,6 @@ export function AwardModal({ open, onClose, receiver }: Props) {
               {loading ? 'Awarding…' : `Award ${clampedPct}%`}
             </button>
           </form>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/CancelProposalModal.tsx
+++ b/web/components/CancelProposalModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { cancelProposal } from '@/lib/actions'
 import { truncateUrl, type CommitteeRequest } from '@/lib/committee'
 import { ModalShell } from './ModalShell'
@@ -13,15 +14,13 @@ interface Props {
 
 export function CancelProposalModal({ open, onClose, proposal }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setError(null); setDone(false)
+      setError(null)
     }
   }, [open])
 
@@ -31,19 +30,16 @@ export function CancelProposalModal({ open, onClose, proposal }: Props) {
     setLoading(true); setError(null)
     try {
       await cancelProposal(wif, wallet.account!, proposal.request_id)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(`Cancelled proposal #${proposal.request_id}`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
   return (
     <ModalShell open={open} onClose={onClose} title="Cancel proposal">
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Cancelled</p>
-        ) : (
-          <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4">
             <p className="font-prose text-sm text-fg-muted">Remove your proposal from the committee?</p>
             <p className="border-l-2 border-border pl-3 font-mono text-sm text-fg">{truncateUrl(proposal.url, 48)}</p>
             {error && <p className="font-prose text-xs text-acc-red">{error}</p>}
@@ -54,7 +50,6 @@ export function CancelProposalModal({ open, onClose, proposal }: Props) {
               </button>
             </div>
           </div>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/CommitteeVoteModal.tsx
+++ b/web/components/CommitteeVoteModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { voteProposal } from '@/lib/actions'
 import { truncateUrl, type CommitteeRequest } from '@/lib/committee'
 import { ModalShell } from './ModalShell'
@@ -14,15 +15,13 @@ interface Props {
 
 export function CommitteeVoteModal({ open, onClose, proposal, votePercent }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setError(null); setDone(false)
+      setError(null)
     }
   }, [open])
 
@@ -32,10 +31,10 @@ export function CommitteeVoteModal({ open, onClose, proposal, votePercent }: Pro
     setLoading(true); setError(null)
     try {
       await voteProposal(wif, wallet.account!, proposal.request_id, votePercent)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(`Voted on proposal #${proposal.request_id}`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
@@ -54,10 +53,7 @@ export function CommitteeVoteModal({ open, onClose, proposal, votePercent }: Pro
 
   return (
     <ModalShell open={open} onClose={onClose} title={title}>
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : (
-          <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4">
             <p className="font-prose text-sm text-fg-muted">{body}</p>
             <p className="border-l-2 border-border pl-3 font-mono text-sm text-fg">{truncateUrl(proposal.url, 48)}</p>
             {error && <p className="font-prose text-xs text-acc-red">{error}</p>}
@@ -68,7 +64,6 @@ export function CommitteeVoteModal({ open, onClose, proposal, votePercent }: Pro
               </button>
             </div>
           </div>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/CreateProposalModal.tsx
+++ b/web/components/CreateProposalModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { createProposal } from '@/lib/actions'
 import { ModalShell } from './ModalShell'
 
@@ -11,6 +12,7 @@ interface Props {
 
 export function CreateProposalModal({ open, onClose }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [url, setUrl] = useState('')
   const [amountMin, setAmountMin] = useState('0')
   const [amountMax, setAmountMax] = useState('')
@@ -18,8 +20,6 @@ export function CreateProposalModal({ open, onClose }: Props) {
   const [worker, setWorker] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (open) setWorker(wallet.account ?? '')
@@ -27,9 +27,8 @@ export function CreateProposalModal({ open, onClose }: Props) {
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
       setUrl(''); setAmountMin('0'); setAmountMax(''); setDays(''); setWorker('')
-      setError(null); setDone(false)
+      setError(null)
     }
   }, [open])
 
@@ -54,19 +53,16 @@ export function CreateProposalModal({ open, onClose }: Props) {
         `${maxN.toFixed(3)} VIZ`,
         daysN * 86400
       )
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success('Proposal created')
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
   return (
     <ModalShell open={open} onClose={onClose} title="New proposal">
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Submitted</p>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <div className="flex flex-col gap-1.5">
               <label htmlFor="cp-url" className="text-[10px] font-prose font-semibold uppercase tracking-widest text-fg-dim">
                 Details URL <span className="text-acc-red">*</span>
@@ -112,7 +108,6 @@ export function CreateProposalModal({ open, onClose }: Props) {
               {loading ? 'Submitting…' : 'Submit proposal'}
             </button>
           </form>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/DelegateModal.tsx
+++ b/web/components/DelegateModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { delegateShares } from '@/lib/actions'
 import { ModalShell } from './ModalShell'
 
@@ -11,17 +12,15 @@ interface Props {
 
 export function DelegateModal({ open, onClose }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [delegatee, setDelegatee] = useState('')
   const [amount, setAmount] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setDelegatee(''); setAmount(''); setError(null); setDone(false)
+      setDelegatee(''); setAmount(''); setError(null)
     }
   }, [open])
 
@@ -34,10 +33,10 @@ export function DelegateModal({ open, onClose }: Props) {
     setLoading(true); setError(null)
     try {
       await delegateShares(wif, wallet.account!, delegatee.trim(), `${n.toFixed(6)} SHARES`)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(`Delegated ${n.toFixed(6)} SHARES to @${delegatee.trim()}`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
@@ -46,10 +45,7 @@ export function DelegateModal({ open, onClose }: Props) {
 
   return (
     <ModalShell open={open} onClose={onClose} title="Delegate SHARES">
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <div className="flex flex-col gap-1.5">
               <label htmlFor="delegate-delegatee" className="text-[10px] font-prose font-semibold uppercase tracking-widest text-fg-dim">Delegatee account</label>
               <input
@@ -85,7 +81,6 @@ export function DelegateModal({ open, onClose }: Props) {
               {loading ? 'Processing…' : isUndelegate ? 'Remove delegation' : `Delegate ${n.toFixed(6)} SHARES`}
             </button>
           </form>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/PowerDownModal.tsx
+++ b/web/components/PowerDownModal.tsx
@@ -1,7 +1,8 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { createHttpTransport, createReadApi } from '@viz-cx/core'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { powerDown } from '@/lib/actions'
 import { NODE_ENDPOINTS } from '@/lib/config'
 import { formatUTC } from '@/lib/format'
@@ -21,19 +22,17 @@ interface PowerDownStatus {
 
 export function PowerDownModal({ open, onClose }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [amount, setAmount] = useState('')
   const [step, setStep] = useState<Step>('form')
   const [activeStatus, setActiveStatus] = useState<PowerDownStatus | null>(null)
   const [loadingStatus, setLoadingStatus] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setAmount(''); setStep('form'); setError(null); setDone(false); setActiveStatus(null)
+      setAmount(''); setStep('form'); setError(null); setActiveStatus(null)
     }
   }, [open])
 
@@ -63,10 +62,10 @@ export function PowerDownModal({ open, onClose }: Props) {
     setLoading(true); setError(null)
     try {
       await powerDown(wif, wallet.account!, '0.000000 SHARES')
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success('Power-down stopped')
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
@@ -84,11 +83,10 @@ export function PowerDownModal({ open, onClose }: Props) {
     setLoading(true); setError(null)
     try {
       await powerDown(wif, wallet.account!, `${parseFloat(amount).toFixed(6)} SHARES`)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success('Power-down started')
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
-      setStep('form')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
@@ -96,10 +94,7 @@ export function PowerDownModal({ open, onClose }: Props) {
 
   return (
     <ModalShell open={open} onClose={onClose} title="Power Down (SHARES → VIZ)">
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : (
-          <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4">
             {loadingStatus && <p className="font-prose text-xs text-fg-dim">Checking status…</p>}
 
             {activeStatus && (
@@ -160,7 +155,6 @@ export function PowerDownModal({ open, onClose }: Props) {
               </form>
             )}
           </div>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/PowerUpModal.tsx
+++ b/web/components/PowerUpModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { powerUp } from '@/lib/actions'
 import { ModalShell } from './ModalShell'
 
@@ -11,17 +12,15 @@ interface Props {
 
 export function PowerUpModal({ open, onClose }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [amount, setAmount] = useState('')
   const [to, setTo] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setAmount(''); setError(null); setDone(false)
+      setAmount(''); setError(null)
     } else {
       setTo(wallet.account ?? '')
     }
@@ -36,19 +35,16 @@ export function PowerUpModal({ open, onClose }: Props) {
     setError(null); setLoading(true)
     try {
       await powerUp(wif, wallet.account!, to.trim() || wallet.account!, `${n.toFixed(3)} VIZ`)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(`Powered up ${n.toFixed(3)} VIZ`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
   return (
     <ModalShell open={open} onClose={onClose} title="Power Up (VIZ → SHARES)">
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <div className="flex flex-col gap-1.5">
               <label htmlFor="powerup-amount" className="text-[10px] font-prose font-semibold uppercase tracking-widest text-fg-dim">Amount (VIZ)</label>
               <input
@@ -84,7 +80,6 @@ export function PowerUpModal({ open, onClose }: Props) {
               {loading ? 'Staking…' : 'Power Up'}
             </button>
           </form>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/TransferModal.tsx
+++ b/web/components/TransferModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { sendTransfer } from '@/lib/actions'
 import { ModalShell } from './ModalShell'
 
@@ -13,19 +14,17 @@ type Step = 'form' | 'confirm'
 
 export function TransferModal({ open, onClose }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [to, setTo] = useState('')
   const [amount, setAmount] = useState('')
   const [memo, setMemo] = useState('')
   const [step, setStep] = useState<Step>('form')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setTo(''); setAmount(''); setMemo(''); setStep('form'); setError(null); setDone(false)
+      setTo(''); setAmount(''); setMemo(''); setStep('form'); setError(null)
     }
   }, [open])
 
@@ -45,19 +44,16 @@ export function TransferModal({ open, onClose }: Props) {
     try {
       const formatted = `${parseFloat(amount).toFixed(3)} VIZ`
       await sendTransfer(wif, wallet.account!, to.trim(), formatted, memo || undefined)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(`Sent ${formatted} to @${to.trim()}`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
-      setStep('form')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
   return (
     <ModalShell open={open} onClose={onClose} title="Transfer">
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : step === 'confirm' ? (
+        {step === 'confirm' ? (
           <div className="flex flex-col gap-4">
             <p className="font-prose text-sm text-fg">
               Send <span className="font-mono text-acc-green">{parseFloat(amount).toFixed(3)} VIZ</span> to{' '}

--- a/web/components/ValidatorProxyModal.tsx
+++ b/web/components/ValidatorProxyModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { setValidatorProxy } from '@/lib/actions'
 import { ModalShell } from './ModalShell'
 
@@ -15,17 +16,15 @@ const NAME_RE = /^[a-z][a-z0-9-.]{2,24}$/
 
 export function ValidatorProxyModal({ open, onClose, mode, currentProxy }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [target, setTarget] = useState('')
   const [review, setReview] = useState(false)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setTarget(''); setReview(false); setError(null); setDone(false); setLoading(false)
+      setTarget(''); setReview(false); setError(null); setLoading(false)
     }
   }, [open])
 
@@ -44,10 +43,10 @@ export function ValidatorProxyModal({ open, onClose, mode, currentProxy }: Props
     setLoading(true); setError(null)
     try {
       await setValidatorProxy(wif, wallet.account!, proxy)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(mode === 'clear' ? 'Vote proxy cleared' : `Proxy set to @${proxy}`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
@@ -56,9 +55,7 @@ export function ValidatorProxyModal({ open, onClose, mode, currentProxy }: Props
 
   return (
     <ModalShell open={open} onClose={onClose} title={title}>
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : !showReview ? (
+        {!showReview ? (
           <div className="flex flex-col gap-4">
             <label className="font-prose text-sm text-fg-muted">
               Delegate all your validator votes to:

--- a/web/components/ValidatorVoteModal.tsx
+++ b/web/components/ValidatorVoteModal.tsx
@@ -1,6 +1,7 @@
 'use client'
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import { useWallet } from '@/lib/wallet'
+import { useToast } from '@/lib/toast'
 import { voteValidator } from '@/lib/actions'
 import { ModalShell } from './ModalShell'
 
@@ -13,15 +14,13 @@ interface Props {
 
 export function ValidatorVoteModal({ open, onClose, validator, currentlyVoted }: Props) {
   const wallet = useWallet()
+  const toast = useToast()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [done, setDone] = useState(false)
-  const doneTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     if (!open) {
-      if (doneTimerRef.current) { clearTimeout(doneTimerRef.current); doneTimerRef.current = null }
-      setError(null); setDone(false)
+      setError(null)
     }
   }, [open])
 
@@ -31,19 +30,16 @@ export function ValidatorVoteModal({ open, onClose, validator, currentlyVoted }:
     setLoading(true); setError(null)
     try {
       await voteValidator(wif, wallet.account!, validator, !currentlyVoted)
-      setDone(true)
-      doneTimerRef.current = setTimeout(onClose, 1500)
+      toast.success(`${currentlyVoted ? 'Removed vote for' : 'Voted for'} @${validator}`)
+      onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Transaction failed')
+      toast.error(err instanceof Error ? err.message : 'Transaction failed')
     } finally { setLoading(false) }
   }
 
   return (
     <ModalShell open={open} onClose={onClose} title={currentlyVoted ? 'Remove vote' : 'Vote for validator'}>
-        {done ? (
-          <p className="py-6 text-center font-mono text-sm text-acc-green">✓ Done</p>
-        ) : (
-          <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4">
             <p className="font-prose text-sm text-fg">
               {currentlyVoted
                 ? <><span>Remove vote for </span><span className="font-mono text-fg-muted">@{validator}</span><span>?</span></>
@@ -62,7 +58,6 @@ export function ValidatorVoteModal({ open, onClose, validator, currentlyVoted }:
               </button>
             </div>
           </div>
-        )}
     </ModalShell>
   )
 }

--- a/web/components/WalletLayout.tsx
+++ b/web/components/WalletLayout.tsx
@@ -1,6 +1,7 @@
 'use client'
 import type { ReactNode } from 'react'
 import { WalletProvider, useWallet } from '@/lib/wallet'
+import { ToastProvider } from '@/lib/toast'
 import { ConnectModal } from './ConnectModal'
 
 function ModalMount() {
@@ -10,9 +11,11 @@ function ModalMount() {
 
 export function WalletLayout({ children }: { children: ReactNode }) {
   return (
-    <WalletProvider>
-      {children}
-      <ModalMount />
-    </WalletProvider>
+    <ToastProvider>
+      <WalletProvider>
+        {children}
+        <ModalMount />
+      </WalletProvider>
+    </ToastProvider>
   )
 }

--- a/web/lib/__tests__/toast.test.ts
+++ b/web/lib/__tests__/toast.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { toastReducer, TOAST_DURATION, MAX_TOASTS, type Toast } from '@/lib/toast'
+
+const mk = (id: number, kind: Toast['kind'] = 'success'): Toast => ({ id, kind, message: `m${id}` })
+
+describe('toastReducer', () => {
+  it('appends an added toast', () => {
+    const next = toastReducer([], { type: 'add', toast: mk(1) })
+    expect(next).toEqual([mk(1)])
+  })
+
+  it('preserves order of multiple adds', () => {
+    let s: Toast[] = []
+    s = toastReducer(s, { type: 'add', toast: mk(1) })
+    s = toastReducer(s, { type: 'add', toast: mk(2, 'error') })
+    expect(s.map(t => t.id)).toEqual([1, 2])
+    expect(s[1].kind).toBe('error')
+  })
+
+  it('evicts the oldest when exceeding MAX_TOASTS', () => {
+    let s: Toast[] = []
+    for (let i = 1; i <= MAX_TOASTS + 2; i++) s = toastReducer(s, { type: 'add', toast: mk(i) })
+    expect(s).toHaveLength(MAX_TOASTS)
+    expect(s.map(t => t.id)).toEqual([3, 4, 5, 6]) // oldest (1,2) dropped
+  })
+
+  it('removes by id', () => {
+    const start = [mk(1), mk(2), mk(3)]
+    expect(toastReducer(start, { type: 'remove', id: 2 }).map(t => t.id)).toEqual([1, 3])
+  })
+
+  it('remove of a missing id is a no-op', () => {
+    const start = [mk(1)]
+    expect(toastReducer(start, { type: 'remove', id: 99 })).toEqual(start)
+  })
+
+  it('exposes the agreed durations', () => {
+    expect(TOAST_DURATION.success).toBe(4000)
+    expect(TOAST_DURATION.error).toBe(7000)
+  })
+})

--- a/web/lib/toast.tsx
+++ b/web/lib/toast.tsx
@@ -1,0 +1,113 @@
+'use client'
+import {
+  createContext, useCallback, useContext, useEffect, useMemo,
+  useReducer, useRef, useState, type ReactNode,
+} from 'react'
+import { createPortal } from 'react-dom'
+
+export type ToastKind = 'success' | 'error'
+export interface Toast { id: number; kind: ToastKind; message: string }
+
+export const TOAST_DURATION: Record<ToastKind, number> = { success: 4000, error: 7000 }
+export const MAX_TOASTS = 4
+
+type Action = { type: 'add'; toast: Toast } | { type: 'remove'; id: number }
+
+export function toastReducer(state: Toast[], action: Action): Toast[] {
+  switch (action.type) {
+    case 'add': {
+      const next = [...state, action.toast]
+      return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next
+    }
+    case 'remove':
+      return state.filter(t => t.id !== action.id)
+    default:
+      return state
+  }
+}
+
+interface ToastApi {
+  success: (message: string) => void
+  error: (message: string) => void
+  dismiss: (id: number) => void
+}
+
+const ToastContext = createContext<ToastApi | null>(null)
+
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used inside ToastProvider')
+  return ctx
+}
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, dispatch] = useReducer(toastReducer, [])
+  const idRef = useRef(0)
+  const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismiss = useCallback((id: number) => {
+    const t = timersRef.current.get(id)
+    if (t) { clearTimeout(t); timersRef.current.delete(id) }
+    dispatch({ type: 'remove', id })
+  }, [])
+
+  const push = useCallback((kind: ToastKind, message: string) => {
+    const id = ++idRef.current
+    dispatch({ type: 'add', toast: { id, kind, message } })
+    timersRef.current.set(id, setTimeout(() => dismiss(id), TOAST_DURATION[kind]))
+  }, [dismiss])
+
+  const api = useMemo<ToastApi>(() => ({
+    success: (m: string) => push('success', m),
+    error: (m: string) => push('error', m),
+    dismiss,
+  }), [push, dismiss])
+
+  useEffect(() => {
+    const timers = timersRef.current
+    return () => { timers.forEach(clearTimeout); timers.clear() }
+  }, [])
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <ToastViewport toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  )
+}
+
+function ToastViewport({ toasts, onDismiss }: { toasts: Toast[]; onDismiss: (id: number) => void }) {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => { setMounted(true) }, [])
+  if (!mounted) return null
+
+  return createPortal(
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed right-4 top-4 z-[60] flex w-full max-w-sm flex-col gap-2"
+    >
+      {toasts.map(t => (
+        <div
+          key={t.id}
+          role={t.kind === 'error' ? 'alert' : 'status'}
+          className={`toast-enter pointer-events-auto flex items-start gap-3 rounded-lg border border-border bg-surface p-3 shadow-xl ${
+            t.kind === 'success' ? 'border-l-2 border-l-acc-green' : 'border-l-2 border-l-acc-red'
+          }`}
+        >
+          <span className={`font-mono text-sm ${t.kind === 'success' ? 'text-acc-green' : 'text-acc-red'}`}>
+            {t.kind === 'success' ? '✓' : '✕'}
+          </span>
+          <p className="flex-1 font-prose text-sm text-fg">{t.message}</p>
+          <button
+            onClick={() => onDismiss(t.id)}
+            className="text-lg leading-none text-fg-dim hover:text-fg"
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>,
+    document.body,
+  )
+}


### PR DESCRIPTION
Replaces the in-place `✓ Done` / inline broadcast-error feedback in every broadcast action modal with a global top-right toast notification system.

## What changed
- **New `web/lib/toast.tsx`** — hand-rolled React context (`useToast()` with `success`/`error`/`dismiss`), backed by a pure `toastReducer` (unit-testable in the node test env). `ToastViewport` portals a top-right stack to `document.body` at `z-[60]` (above the modal overlay's `z-50`). Auto-dismiss: success 4s, error 7s; max 4 toasts (oldest evicted); `prefers-reduced-motion` respected.
- **`ToastProvider` mounted in `WalletLayout`** so all modals can call `useToast()`; slide-in keyframe added to `globals.css`.
- **10 broadcast modals refactored** (Transfer, PowerDown, ValidatorProxy, CommitteeVote, CancelProposal, ValidatorVote, Award, Delegate, PowerUp, CreateProposal): success → toast + immediate close; broadcast error → error toast while staying on the review step for one-click retry. Inline field-validation errors stay inline, unchanged.

## Notes
- `ValidatorProxyModal` success message is mode-aware (`Vote proxy cleared` vs `Proxy set to @x`) — the plan's single string would have rendered "Proxy set to @" in clear mode.
- `AccountHistory`'s `done`/`setDone` is a pagination flag, not broadcast feedback — correctly left untouched.
- No new runtime dependencies (avoids the dual lockfile).

## Gates
- `npm test` — 62 passing (6 new reducer tests)
- `npx tsc --noEmit` — clean
- `npx next build` — succeeds